### PR TITLE
Enable client-side JS

### DIFF
--- a/packages/leo-core/runtime-assets/entry-client.js
+++ b/packages/leo-core/runtime-assets/entry-client.js
@@ -1,56 +1,77 @@
-import createBrowserHistory from 'history/lib/createBrowserHistory';
 import IsomorphicRelay from 'isomorphic-relay';
 import Relay from 'react-relay';
-import IsomorphicRouter, {
-  Router
-} from 'isomorphic-relay-router';
+import IsomorphicRouter from 'isomorphic-relay-router';
+import IsomorphicRelayRouterContext from 'isomorphic-relay-router/lib/IsomorphicRelayRouterContext';
+import useRelay from 'react-router-relay';
+import {
+  applyRouterMiddleware,
+  Router,
+  Route,
+  match,
+  browserHistory
+} from 'react-router';
 import React from 'react';
 import ReactDOM, { render } from 'react-dom';
 import md5 from 'md5';
-import request from 'superagent';
+const debug = require('debug')('leo:entry-client');
 
 import routes from './load-routes';
-import conf from './load-leorc';
+//import { conf } from './inserted-files';
 
-console.log('routes', routes);
+// Set up Relay Environment
+const environment = new Relay.Environment();
+environment.injectNetworkLayer(new Relay.DefaultNetworkLayer('/graphql'));
 
-var myNetworkLayer = {
-  sendMutation(mutationRequest) {
-    // ...
-  },
-  sendQueries(queryRequests) {
-    console.log('queryRequests', queryRequests);
-    return Promise.all(queryRequests.map(
-      queryRequest => {
-        const query = queryRequest.getQueryString();
-        console.log('query', query);
-        const graphQLQueryHash = md5(query)
-        request(`/api/${graphQLQueryHash}.json`)
-        .end((err, res) => {
-          if(err) {
-             queryRequest.reject(new Error(err));
-          } else if (res.body && res.body.errors) {
-            queryRequest.reject(new Error(res.body.errors));
-          } else {
-            console.log('res.body', res.body);
-            queryRequest.resolve({ response: res.body.data });
-          }
-        })
-    }
-    ));
-  },
-  supports(...options) {
-    // ...
-  },
-};
+// Inject Data from DOM (and network?)
+const data = JSON.parse(document.getElementById('preloadedData').textContent);
+IsomorphicRelay.injectPreparedData(environment, data);
 
-Relay.injectNetworkLayer(myNetworkLayer);
+let cachedData = {};
+function onChange(prevState, nextState, replace, cb) {
+  /**
+   * fetch JSON files before Relay has a chance to know it didn't have the data
+   * This allows us to preload Relay's store so it doesn't make requests.
+   *
+   * We cache the data locally by hash of route. This is adequate for pageviews
+   * but not for localstorage since the hashes of routes can change contents.
+   */
+  const hash = md5(window.location.pathname);
+  if(!cachedData[hash]) {
+    debug(`requesting ${hash}.json`);
+    fetch(`/api/${hash}.json`)
+                       .then(response => response.json())
+                       .then(result => {
+                         if(result.errors) {
+                           cb('errors in json');
+                         } else {
+                           IsomorphicRelay.injectPreparedData(environment, result);
+                           cachedData[hash] = true;
+                           cb();
+                         }
+                       })
+                       .catch(err => {
+                         console.log('new error');
+                         cb('error fetching json');
+                       })
+  } else {
+    debug(`${hash}.json has already been loaded`);
+    cb();
+  }
+}
 
 // Client render (optional):
 if (typeof document !== 'undefined') {
-  console.log('using client render');
+  debug('using client render');
   const outlet = document.getElementById('react-mount');
 
-  render(<Router history={createBrowserHistory()} routes={routes} />, outlet);
+  // use the same routes object as on the server
+  match({
+    routes: <Route onChange={onChange}>{routes}</Route>,
+    history: browserHistory
+  }, (error, redirectLocation, renderProps) => {
+    IsomorphicRouter.prepareInitialRender(environment, renderProps).then(props => {
+      debug('prepareInitialRender');
+      ReactDOM.render(<Router {...props} />, outlet);
+    });
+  });
 }
-console.log('clientXFGJK')

--- a/packages/leo-core/runtime-assets/entry-static-watch.js
+++ b/packages/leo-core/runtime-assets/entry-static-watch.js
@@ -35,6 +35,11 @@ export default (locals, callback) => {
     } else {
 
       IsomorphicRouter.prepareData(renderProps, networkLayer).then(({ data, props }) => {
+        console.log(`renderingJSON at ${locals.jsonOutputFileName}`);
+        _globalJSONAsset({
+          name: locals.jsonOutputFileName,
+          json: data
+        })
         try {
           const body = renderToString(IsomorphicRouter.render(props));
           /**
@@ -49,6 +54,7 @@ export default (locals, callback) => {
                   assets={locals.assets}
                   bundleAssets={locals.assetsPluginHash}
                   props={props}
+                  data={data}
             />
           )
             callback(null, htmlAsString);

--- a/packages/leo-core/src/develop.js
+++ b/packages/leo-core/src/develop.js
@@ -47,8 +47,8 @@ export default () => {
        * Enable third party plugins.
        * This is where we hook in to allow things like `npm i leo-blogpost`
        */
-      const configWithUrlsAndPlugins = enablePlugins(conf, configWithUrls);
-      webpack(configWithUrlsAndPlugins.resolve()).run((err, stats) => {
+      const configWithUrlsAndPlugins = configWithUrls.map(c => enablePlugins(conf, c));
+      webpack(configWithUrlsAndPlugins.map(c => c.resolve())).run((err, stats) => {
         if (err) {
           // hard failure
           return console.error(chalk.red(err));

--- a/packages/leo-plugin-markdown/index.js
+++ b/packages/leo-plugin-markdown/index.js
@@ -8,7 +8,7 @@ module.exports = function configure(config, opts) {
   config.merge((current) => {
     current.resolve.extensions.push('.md');
     current['@saLabs/leoPluginMarkdown/loader'] = {
-      instance: opts.instance || require('markdown-it')({
+      instance: opts && opts.instance || require('markdown-it')({
         html: true,
         linkify: true,
         typographer: true,


### PR DESCRIPTION
* Move to multi-compiler webpack.
  - Potential Problem: figuring out how to hash client.js and use it
  in static.js' html generation
* Use debug in strategic places instead of console.logs


`_globalJSONAsset` is injected into the static.js scope as a global
variable. This function can be used to write out JSON files that come
back from Relay requests. This allows us to generate a flat-file .json
API which we can consume via fetch on the client side. This completely
eliminates any dependency on a foreign graphql server at runtime.


.json files are saved as an md5 hash of the window.location. This
means they are not forever-cacheable like a content-addressable
solution might be. We might be able to fix this by mapping
content-adressable hashes to window.location and injecting the hash
where we do the fetch for the JSON file.

Files are currently fetched in `onChange` of the topmost wrapper route
(magically, from a user's point of view). This means we block render
until the file is fetched so Relay can be tricked into not making an
additional request. Fixing this is probably more involved, but a dirty
hack in writing a custom network layer sendQueries was able to get it
mostly there.