### PR TITLE
Upgrade to Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![header](./assets/header.png)
 
+* [Why](#why)
 * [Leo](#leo)
   - [Data](#data)
   - [Templates](#templates)
@@ -10,87 +11,41 @@
   - [Plugins](docs/plugins.md)
   - [Developing](docs/developing.md)
 
-> Leo is a highly extensible, declarative static site generator.
+# Why LEO?
+
+LEO is a library for creating Static Site Generators with a common
+GraphQL data layer. Typically, one would use a LEO generator to build
+static sites from Single Page Applications. This is a different
+approach to generators such as Jekyll and Hugo which use template
+languages. See the [Comparison to Other Generators]().
+
+You may want to choose a pre-built generator such as React from the
+[Quick Start]() section.
 
 <h4 align="center">Data</h4>
 
-Declare the data components need to render a set of pages using an
-extensible, product-based API.
+Data in LEO is exposed through a composable, extensible GraphQL
+Schema defining Content Types. It can be queried with any valid
+GraphQL client (such as
+[Apollo](https://github.com/apollostack/apollo-client) or
+[GraphiQL]() for development).
 
 ```javascript
-post(slug: $slug) {
-  attributes { title, date, timeToRead }
-  body
-}
-```
-
-<h4 align="center">Templates</h4>
-
-Use [React][react] to build up a declarative, reusable library of
-components and share them across projects. Using JavaScript means
-never being stuck with a restricted template language.
-
-```javascript
-class Post extends Component {
-  static propTypes = {
-    title: string,
-    date: string,
-    exerpt: string,
-    timetoRead: number,
-    url: string
-  };
-
-  render() {
-    const {
-      title, date, excerpt, timeToRead, url
-    } = this.props.post.attributes;
-    return (
-      <div className="post">
-        <div className="image"></div>
-        <Link to={url}><h4 className="heading">{title}</h4></Link>
-        <span className="meta">{date} &bull; {timeToRead} min read</span>
-        <p className="excerpt">{excerpt}</p>
-        <Link to={url} className="readMore">Read more...</Link>
-      </div>
-    )
+query BlogPostPage {
+  post(slug: $slug) {
+    attributes { title, date, timeToRead }
+    body
   }
 }
 ```
 
-<h4 align="center">Routing</h4>
-
-Declarative routing with [React Router][react-router]. Make the URL
-your first thought, not an after-thought.
-
-```javascript
-export default (
-  <Route path='/' component={App}>
-    <Route path='/posts/'
-           queries={RootQuery}
-           component={Posts} />
-    <Route path=':slug'
-           component={Post}
-           queries={RootQuery} />
-    <Route path='/:year/:month/:day/:slug/'
-           component={Post}
-           queries={RootQuery} />
-    <IndexRoute component={Home} 
-           queries={RootQuery}/>
-    <Route path='*' component={NoMatch} />
-  </Route>
-)
-```
-
 # Why Leo?
 
-* Declarative Approach
-* Extensible (via Plugins)
-* Reuse SPA Skills
-* Extremely Flexible
+* [GraphQL Data Layer](docs/graphql-data-layer)
+* Use any UI tech (React, Glamor, Inferno, etc)
+* Webpack based extensibility
+* Structured Content Types (Markdown, Blogpost, Contentful)
 * Reuse Component Libraries Across Client Projects
-* Write Content in Markdown, Latex, etc
-* Automatically Optimize Images
-* No Template Languages
 
 ## Optional Modern Client-Side JS
 

--- a/docs/graphql-data-layer.md
+++ b/docs/graphql-data-layer.md
@@ -1,0 +1,15 @@
+# GraphQL Data Layer
+
+LEO boasts a composable GraphQL data layer which can be reused with
+any scaffolding. The data layer consists of
+[Content Types](#content-types), [post processing](#post-processing)
+and [querying](#querying).
+
+## Content Types
+
+Content Types are the fundamental units of data when working with LEO
+based sites. 
+
+## Post Processing
+
+## Querying

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "eval": "^0.1.1",
     "frontmatter-loader": "0.0.1",
     "json-loader": "^0.5.4",
-    "memory-fs": "^0.3.0",
+    "memory-fs": "^0.4.1",
     "nyc": "^10.0.0",
-    "webpack": "^1.13.3"
+    "webpack": "^2.2.0-rc.1"
   },
   "devDependencies": {
     "commitizen": "^2.8.6",

--- a/packages/graphql-directory-api/__tests__/blogpost.js
+++ b/packages/graphql-directory-api/__tests__/blogpost.js
@@ -30,4 +30,36 @@ describe('leo-plugin-blogpost', () => {
       done();
     })
   });
+
+  it('should handle .post content with a custom markdown instance', done => {
+    let rawFile = fs.readFileSync('./__utils__/instrumenting-servant-with-prometheus/index.post', 'utf-8');
+    let lines = rawFile.split('\n');
+    lines.splice(0,5);
+    const rawBody = lines.join('\n');
+
+    generate({
+      memoryFS: true,
+      files: [
+        './__utils__/instrumenting-servant-with-prometheus/index.post'
+      ],
+      plugins: [
+        "@sa-labs/leo-plugin-blogpost",
+        "@sa-labs/leo-plugin-markdown",
+        "@sa-labs/leo-plugin-images"
+      ],
+      pluginOpts: {
+        "@sa-labs/leo-plugin-markdown": {
+          instance: require('markdown-it')()
+        }
+      }
+    }, (err, { data, schema }={}) => {
+      expect(err).toBeNull();
+      expect(schema).toEqual(jasmine.any(GraphQLSchema));
+      expect(Array.isArray(data)).toEqual(true);
+      expect(data[0].attributes.slug).toBe('instrumenting-servant-with-prometheus');
+      expect(data[0].rawBody).toBe(rawBody);
+      done();
+    })
+  });
+
 })

--- a/packages/graphql-directory-api/__utils__/text/index.js
+++ b/packages/graphql-directory-api/__utils__/text/index.js
@@ -1,15 +1,11 @@
 module.exports = function configure(config, opts) {
-  config.loader('text', {
+  config.module.rules.push({
     test: /\.md$/,
     exclude: /node_modules/,
-    loaders: ['./__utils__/text/loader']
+    use: [{
+      loader: './__utils__/text/loader'
+    }]
   });
-  config.merge((current) => {
-    current.resolve.extensions.push('.md');
-    current['text/loader'] = {
-    }
-    return current;
-  })
 
   return config;
 }

--- a/packages/graphql-directory-api/package.json
+++ b/packages/graphql-directory-api/package.json
@@ -38,6 +38,6 @@
     "lodash": "^4.16.4",
     "memory-fs": "^0.3.0",
     "mkdirp": "^0.5.1",
-    "webpack": "^1.13.2"
+    "webpack": "^2.2.0-rc.1"
   }
 }

--- a/packages/graphql-directory-api/package.json
+++ b/packages/graphql-directory-api/package.json
@@ -38,7 +38,6 @@
     "lodash": "^4.16.4",
     "memory-fs": "^0.3.0",
     "mkdirp": "^0.5.1",
-    "webpack": "^1.13.2",
-    "webpack-configurator": "^0.3.1"
+    "webpack": "^1.13.2"
   }
 }

--- a/packages/graphql-directory-api/src/gen-database/index.js
+++ b/packages/graphql-directory-api/src/gen-database/index.js
@@ -55,7 +55,15 @@ export default function genDatabase({
     outputPath: distFolder
   }));
 
-  const compiler = webpack(createdConfig);
+  let compiler;
+  try {
+    compiler = webpack(createdConfig);
+  } catch (e) {
+    console.log('webpack error');
+    console.log(e.message);
+    throw e;
+  }
+
   if(memoryFS) {
     fs = new MemoryFS();
     compiler.outputFileSystem = fs;
@@ -87,6 +95,7 @@ export default function genDatabase({
     debug('dist output', fs.readdirSync(distFolder));
     const apiJSONAsString = fs.readFileSync(resolve(distFolder, 'database-bundle.js'), 'utf-8');
     const apiJSON = evaluate(apiJSONAsString, 'api-database.json', null, true);
+    debug('apiJSON count', apiJSON.length);
     letPluginsPostProcessData(plugins, apiJSON, (err, resultingData) => {
       if(err) {
         debug('caught err', err);

--- a/packages/graphql-directory-api/src/gen-database/index.js
+++ b/packages/graphql-directory-api/src/gen-database/index.js
@@ -55,7 +55,7 @@ export default function genDatabase({
     outputPath: distFolder
   }));
 
-  const compiler = webpack(createdConfig.resolve());
+  const compiler = webpack(createdConfig);
   if(memoryFS) {
     fs = new MemoryFS();
     compiler.outputFileSystem = fs;

--- a/packages/graphql-directory-api/src/gen-database/loaders/database-loader.js
+++ b/packages/graphql-directory-api/src/gen-database/loaders/database-loader.js
@@ -31,7 +31,9 @@ function mkRequireArray(paths) {
 
 module.exports = function(content, map) {
   this.cacheable && this.cacheable();
-  const options = this.options.database || {};
-  const { files=[] } = options;
+  const {
+    files=[]
+  } = loaderUtils.parseQuery(this.query);
+  debug('files', files);
   return mkRequireArray(files)
 }

--- a/packages/graphql-directory-api/src/gen-database/loaders/database-loader.test.js
+++ b/packages/graphql-directory-api/src/gen-database/loaders/database-loader.test.js
@@ -24,13 +24,11 @@ describe('index', () => {
 
   it('generates a database', () => {
     expect(loader.bind({
-      options: {
-        database: {
+      query: '?' + JSON.stringify({
           files: [
             resolve(process.cwd(), './__utils__/database-loader-file.txt')
           ]
-        }
-      }
+      })
     })()).toEqual(`module.exports = [require("${process.cwd()}/__utils__/database-loader-file.txt")];`);
   });
 });

--- a/packages/graphql-directory-api/src/gen-database/webpack.config.js
+++ b/packages/graphql-directory-api/src/gen-database/webpack.config.js
@@ -12,19 +12,19 @@ export default ({ filepaths, plugins }: WebpackOpts,
   // merge some initial config in
   const config = {
     target: 'node',
-    entry: 'database-loader!',//resolve(__dirname, '../runtime-assets/entry-database.js'),
+    entry: `database-loader?${JSON.stringify({files: filepaths})}!`,
     output: {
       path: outputPath,
       filename: 'database-bundle.js',
-      library: true,
+      library: 'LEODatabase',
       libraryTarget: 'commonjs2'
     },
 
     resolve: {
-      extensions: ['', '.js', '.json']
+      extensions: ['.js', '.json']
     },
     resolveLoader: {
-      modulesDirectories: [
+      modules: [
         'node_modules',
         /**
          * Allow custom loaders to be accessed without specifying the full
@@ -40,20 +40,16 @@ export default ({ filepaths, plugins }: WebpackOpts,
         /get-plugin-schemas/,
         /enable-plugins/,
       ],
-      loaders: [{
+      rules: [{
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'stage-0']
-        }
-      },{
-        test: /load-database-files.js$/,
-        loaders: ['database-loader', 'babel']
+        use: [{
+          loader: 'babel-loader',
+          options: {
+            presets: ['es2015', 'stage-0']
+          }
+        }]
       }]
-    },
-    database: {
-      files: filepaths
     }
   };
 

--- a/packages/graphql-directory-api/src/gen-database/webpack.config.js
+++ b/packages/graphql-directory-api/src/gen-database/webpack.config.js
@@ -1,5 +1,4 @@
 /* @flow */
-import Config from 'webpack-configurator';
 import { resolve } from 'path';
 import webpack from 'webpack';
 
@@ -10,10 +9,8 @@ type WebpackOpts = {|
 
 export default ({ filepaths, plugins }: WebpackOpts,
                 { outputPath }: {| outputPath: string |}) => {
-  // create a new webpack-configurator instance
-  const config = new Config();
   // merge some initial config in
-  config.merge({
+  const config = {
     target: 'node',
     entry: 'database-loader!',//resolve(__dirname, '../runtime-assets/entry-database.js'),
     output: {
@@ -58,7 +55,7 @@ export default ({ filepaths, plugins }: WebpackOpts,
     database: {
       files: filepaths
     }
-  });
+  };
 
   // Allow plugins to add loaders
   return config;

--- a/packages/graphql-directory-api/src/gen-schema/get-plugin-schemas.js
+++ b/packages/graphql-directory-api/src/gen-schema/get-plugin-schemas.js
@@ -1,7 +1,7 @@
 /* @flow */
 import oDebug from 'debug';
 const debug = oDebug('graphql-directory-api:get-plugin-schemas');
-import path from 'path';
+import path, { resolve } from 'path';
 import type { PluginSpec } from './types';
 
 export default function({
@@ -11,14 +11,19 @@ export default function({
   debug('reducing plugin schema');
   return plugins.reduce((acc, pluginString) => {
     const pluginSchemaPath = `${pluginString}/schema`;
+    let pluginPath;
     try {
-      require.resolve(pluginSchemaPath);
+      pluginPath = require.resolve(pluginSchemaPath);
       debug('pluginSchemaPath', pluginSchemaPath);
     } catch (e) {
-      debug('No schema for plugin', pluginString);
-      return acc;
+      try {
+        pluginPath = require.resolve(resolve(process.cwd(), pluginSchemaPath));
+      } catch (e) {
+        debug('No schema for plugin', pluginString);
+        return acc;
+      }
     }
-    const mkPluginSchema = require(pluginSchemaPath);
+    const mkPluginSchema = require(pluginPath);
     /**
      * If plugin/schema is not a function, maybe we should allow it to not be
      * in the future?

--- a/packages/graphql-directory-api/src/gen-schema/index.test.js
+++ b/packages/graphql-directory-api/src/gen-schema/index.test.js
@@ -5,7 +5,9 @@ describe('gen-schema', () => {
   it('generates a schema', () => {
     expect(genSchema({
       data: [],
-      plugins: ['./__utils__/text']
+      plugins: [
+        './__utils__/text'
+      ]
     })).toEqual(jasmine.any(GraphQLSchema))
   });
 })

--- a/packages/leo-core/index.js
+++ b/packages/leo-core/index.js
@@ -2,6 +2,7 @@ var program = require('commander');
 var graphql = require('./src/graphql').default;
 var schema = require('./src/schema').default;
 var develop = require('./src/develop').default;
+var build = require('./src/build').default;
 var db = require('./src/db').default;
 
 program
@@ -12,7 +13,13 @@ program
   .alias('d')
   .description('Develop the site locally. Watch files for changes.')
   .option('-w, --watch', 'Watch mode')
-  .action(develop)
+  .action(develop);
+
+program
+  .command('build')
+  .alias('b')
+  .description('Build the site once with production flags')
+  .action(build);
 
 program
   .command('graphql')

--- a/packages/leo-core/package.json
+++ b/packages/leo-core/package.json
@@ -66,8 +66,7 @@
     "react-router": "^2.3.0",
     "serialize-javascript": "^1.1.2",
     "superagent": "^2.1.0",
-    "webpack": "^1.12.9",
-    "webpack-configurator": "^0.3.1",
+    "webpack": "^1.x",
     "webpack-require": "0.0.16",
     "xmlhttprequest": "^1.8.0"
   }

--- a/packages/leo-core/package.json
+++ b/packages/leo-core/package.json
@@ -66,7 +66,7 @@
     "react-router": "^2.3.0",
     "serialize-javascript": "^1.1.2",
     "superagent": "^2.1.0",
-    "webpack": "^1.x",
+    "webpack": "^2.2.0-rc.1",
     "webpack-require": "0.0.16",
     "xmlhttprequest": "^1.8.0"
   }

--- a/packages/leo-core/src/build.js
+++ b/packages/leo-core/src/build.js
@@ -52,14 +52,12 @@ export default () => {
        */
       const configWithUrlsAndPlugins = Object.entries(configWithUrls)
                                              .map(([key, wpConfig]) => {
-                                               console.log(key, wpConfig);
                                                return enablePlugins({
                                                  bundleType: key,
                                                  config: wpConfig,
                                                  conf,
                                                });
                                              });
-//      console.log('config', configWithUrlsAndPlugins);
       debug('enabled plugins');
       webpack(configWithUrlsAndPlugins).run((err, stats) => {
         debug('ran client and static webpack builds');

--- a/packages/leo-core/src/develop.js
+++ b/packages/leo-core/src/develop.js
@@ -52,7 +52,7 @@ export default () => {
        */
       const configWithUrlsAndPlugins = Object.entries(configWithUrls)
                                              .map(([key, wpConfig]) => {
-                                               console.log(key, wpConfig);
+//                                               console.log(key, wpConfig);
                                                return enablePlugins({
                                                  bundleType: key,
                                                  config: wpConfig,
@@ -61,7 +61,15 @@ export default () => {
                                              });
 //      console.log('config', configWithUrlsAndPlugins);
       debug('enabled plugins');
-      webpack(configWithUrlsAndPlugins).run((err, stats) => {
+      let compiler;
+      try {
+        compiler = webpack(configWithUrlsAndPlugins);
+      } catch (e) {
+        console.log('webpack error');
+        console.log(e.message);
+        throw e;
+      }
+      compiler.run((err, stats) => {
         debug('ran client and static webpack builds');
         if (err) {
           // hard failure

--- a/packages/leo-core/src/webpack.config.build.js
+++ b/packages/leo-core/src/webpack.config.build.js
@@ -69,7 +69,7 @@ export default ({ conf, data, urls }) => {
 
       externals: [/^graphql/],
       resolve: {
-        extensions: ['', '.js', '.json', '.leorc']
+        extensions: ['.js', '.json', '.leorc']
       },
       resolveLoader: {
         modulesDirectories: [
@@ -150,7 +150,7 @@ export default ({ conf, data, urls }) => {
       },
       target: 'web',
       resolve: {
-        extensions: ['', '.js', '.json', '.leorc']
+        extensions: ['.js', '.json', '.leorc']
       },
       plugins: [
         new AssetsPlugin({

--- a/packages/leo-core/src/webpack.config.build.js
+++ b/packages/leo-core/src/webpack.config.build.js
@@ -19,6 +19,9 @@ export default ({ conf, data, urls }) => {
       new webpack.DefinePlugin({
         __LEORC__: JSON.stringify(conf),
         __DATA__: JSON.stringify(data),
+        'process.env':{
+          'NODE_ENV': JSON.stringify('production')
+        }
       })
     ]
     if(conf.define) {
@@ -35,6 +38,7 @@ export default ({ conf, data, urls }) => {
   if(conf.scaffolding) {
     staticEntry = `${conf.scaffolding}/entry-static`
   };
+
   let clientEntry = path.resolve(__dirname, 'entry-client');
   if(conf.scaffolding) {
     clientEntry = `${conf.scaffolding}/entry-client`
@@ -78,6 +82,13 @@ export default ({ conf, data, urls }) => {
         ]
       },
       plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+          compress:{
+            warnings: true
+          }
+        }),
+        // Merge all duplicate modules
+        new webpack.optimize.DedupePlugin(),
         new AssetsPlugin({
           filename: 'webpack-static-assets.json',
           path: path.resolve(process.cwd(), 'dist/js'),
@@ -128,7 +139,6 @@ export default ({ conf, data, urls }) => {
         }]
       }
     },
-
     client: {
       entry: {
         'client': clientEntry
@@ -179,5 +189,5 @@ export default ({ conf, data, urls }) => {
         }]
       }
     }
-  };
+  }
 };

--- a/packages/leo-core/src/webpack.config.develop.js
+++ b/packages/leo-core/src/webpack.config.develop.js
@@ -65,10 +65,10 @@ export default ({ conf, data, urls }) => {
 
       externals: [/^graphql/],
       resolve: {
-        extensions: ['', '.js', '.json', '.leorc']
+        extensions: ['.js', '.json', '.leorc']
       },
       resolveLoader: {
-        modulesDirectories: [
+        modules: [
           'node_modules',
           /**
            * Allow leo's custom loaders to be accessed without specifying the full
@@ -115,16 +115,15 @@ export default ({ conf, data, urls }) => {
           /node_modules\/eval/,
           /get-plugin-schemas/,
         ],
-        loaders: [{
+        rules: [{
           test: /\.jsx?$/,
           exclude: /(graphql|node_modules)/,
-          loader: 'babel',
-          query: {
-            cacheDirectory: path.resolve(process.cwd(), '.babelcache')
-          }
-        }, {
-          test: /\.json/,
-          loader: 'json'
+          use: [{
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: path.resolve(process.cwd(), '.babelcache')
+            }
+          }]
         }]
       }
     },
@@ -140,7 +139,7 @@ export default ({ conf, data, urls }) => {
       },
       target: 'web',
       resolve: {
-        extensions: ['', '.js', '.json', '.leorc']
+        extensions: ['.js', '.json', '.leorc']
       },
       plugins: [
         new AssetsPlugin({
@@ -169,13 +168,12 @@ export default ({ conf, data, urls }) => {
         ...getDefinePlugins(),
       ],
       module: {
-        loaders: [{
+        rules: [{
           test: /\.jsx?$/,
           exclude: /node_modules/,
-          loader: 'babel',
-        }, {
-          test: /\.json/,
-          loader: 'json'
+          use: [{
+            loader: 'babel-loader'
+          }],
         }]
       }
     }

--- a/packages/leo-core/webpack.config.js
+++ b/packages/leo-core/webpack.config.js
@@ -46,7 +46,8 @@ module.exports = {
   },
   externals: nodeModules,
   resolve: {
-    root: [
+    modules: [
+      'node_modules',
       path.resolve('./src')
     ]
   },
@@ -59,13 +60,17 @@ module.exports = {
       /get-plugin-schemas/,
       /let-plugins-post-process-data/,
     ],
-    loaders: [,{
+    rules: [{
       test: /@sa-labs.*\.jsx?$/,
-      loader: 'babel'
+      use: [{
+        loader: 'babel-loader'
+      }]
     }, {
       test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
-      loader: 'babel'
+      use: [{
+        loader: 'babel-loader'
+      }]
     }]
   }
 }

--- a/packages/leo-plugin-blogpost/index.js
+++ b/packages/leo-plugin-blogpost/index.js
@@ -1,17 +1,19 @@
-'use strict';
+module.exports = function configure(config, opts) {
 
-module.exports = function configure(config) {
-
-  config.loader('posts', {
+  config.module.loaders.push({
     test: /\.post$/,
     exclude: /node_modules/,
-    loaders: ['@sa-labs/leo-plugin-blogpost/loader', '@sa-labs/leo-plugin-markdown/loader', 'frontmatter']
+    loaders: [
+      '@sa-labs/leo-plugin-blogpost/loader',
+      '@sa-labs/leo-plugin-markdown/loader',
+      'frontmatter'
+    ]
   });
 
-  config.merge(function (current) {
-    current.resolve.extensions.push('.post');
-    return current;
-  });
-
+  /* config.merge(function (current) {
+     current.resolve.extensions.push('.post');
+     return current;
+     });
+   */
   return config;
 };

--- a/packages/leo-plugin-blogpost/index.js
+++ b/packages/leo-plugin-blogpost/index.js
@@ -1,19 +1,18 @@
-module.exports = function configure(config, opts) {
+'use strict';
 
-  config.module.loaders.push({
+module.exports = function configure(config) {
+
+  config.module.rules.push({
     test: /\.post$/,
     exclude: /node_modules/,
-    loaders: [
-      '@sa-labs/leo-plugin-blogpost/loader',
-      '@sa-labs/leo-plugin-markdown/loader',
-      'frontmatter'
-    ]
+    use: [{
+      loader: '@sa-labs/leo-plugin-blogpost/loader'
+    }, {
+      loader: '@sa-labs/leo-plugin-markdown/loader'
+    }, {
+      loader: 'frontmatter-loader'
+    }]
   });
 
-  /* config.merge(function (current) {
-     current.resolve.extensions.push('.post');
-     return current;
-     });
-   */
   return config;
 };

--- a/packages/leo-plugin-blogpost/loader.js
+++ b/packages/leo-plugin-blogpost/loader.js
@@ -34,6 +34,7 @@ function slugify(str) {
 }
 
 module.exports = function (json) {
+  debug('loading');
   // Signal to webpack this is cacheable
   this.cacheable();
   /**

--- a/packages/leo-plugin-blogpost/schema.js
+++ b/packages/leo-plugin-blogpost/schema.js
@@ -91,10 +91,8 @@ var BlogPostType = new _type.GraphQLObjectType({
 
 var _connectionDefinition = (0, _graphqlRelay.connectionDefinitions)({
   nodeType: BlogPostType
-});
-
-var BlogPostConnection = _connectionDefinition.connectionType;
-
+}),
+    BlogPostConnection = _connectionDefinition.connectionType;
 
 module.exports = function (data) {
   // The set of posts we should return via the API

--- a/packages/leo-plugin-blogpost/src/index.js
+++ b/packages/leo-plugin-blogpost/src/index.js
@@ -1,19 +1,16 @@
 module.exports = function configure(config) {
 
-  config.loader('posts', {
+  config.module.rules.push({
     test: /\.post$/,
     exclude: /node_modules/,
-    loaders: [
-      '@sa-labs/leo-plugin-blogpost/loader',
-      '@sa-labs/leo-plugin-markdown/loader',
-      'frontmatter'
-    ]
+    use: [{
+      loader: '@sa-labs/leo-plugin-blogpost/loader'
+    },{
+      loader: '@sa-labs/leo-plugin-markdown/loader'
+    }, {
+      loader: 'frontmatter-loader'
+    }]
   });
-
-  config.merge((current) => {
-    current.resolve.extensions.push('.post');
-    return current;
-  })
 
   return config;
 }

--- a/packages/leo-plugin-blogpost/src/loader.js
+++ b/packages/leo-plugin-blogpost/src/loader.js
@@ -23,6 +23,7 @@ function slugify(str) {
 }
 
 module.exports = function(json) {
+  debug('loading');
   // Signal to webpack this is cacheable
   this.cacheable();
   /**

--- a/packages/leo-plugin-fate/index.js
+++ b/packages/leo-plugin-fate/index.js
@@ -1,31 +1,42 @@
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var path = require('path');
 var constants = require('@sa-labs/fate-core/manual')();
+var webpack = require('webpack');
 
 module.exports = function configure(config, opts) {
   opts = opts || {};
 
   // Project's CSS. Run CSS in modules mode with postcss
-  config.module.loaders.push({
+  config.module.rules.push({
     test: /\.css$/,
     exclude: /node_modules/,
-    loader: ExtractTextPlugin.extract('style-loader', 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader')
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
+    })
   });
 
   // Project's global css. Run PostCSS but not modules mode.
-  config.module.loaders.push({
+  config.module.rules.push({
     test: /\.global\.css$/,
-    loader: ExtractTextPlugin.extract('style-loader', 'css-loader?importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader')
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: 'css-loader?importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
+    })
   });
 
   // Third Party CSS. From node_modules. Don't process, just load.
-  config.module.loaders.push({
+  config.module.rules.push({
     test: /\.css$/,
     include: /node_modules/,
-    loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: 'css-loader'
+    })
   });
 
-  const extract = new ExtractTextPlugin('styles.[contenthash].css', {
+  const extract = new ExtractTextPlugin({
+    filename: 'styles.[contenthash].css',
     allChunks: true
   });
   if(config.plugins) {
@@ -34,32 +45,11 @@ module.exports = function configure(config, opts) {
     config.plugins = [extract];
   }
 
-  config.postcss = opts.postcss || [
-      require('postcss-import'),
-      require('postcss-brand-colors'),
-      require('postcss-constants')({
-        defaults: constants
-      }),
-      require('postcss-modular-scale')({
-        bases: 1,
-        ratios: 1.5
-      }),
-      require('postcss-responsive-type'),
-      require('postcss-cssnext')({
-        browsers: 'last 2 versions'
-      }),
-      require('lost')({
-        flexbox: 'flex'
-      }),
-      require('postcss-font-magician')({
-        hosted: './static/fonts'
-      }),
-      // require('list-selectors').plugin(function(selectorList) {
-      //   console.log(selectorList)
-      // }),
-//      require('immutable-css'),
-      require('postcss-browser-reporter')
-    ]
+  /* config.plugins.push(new webpack.LoaderOptionsPlugin({
+     options: {
+     context: __dirname
+     }
+     })); */
 
   return config;
 }

--- a/packages/leo-plugin-fate/index.js
+++ b/packages/leo-plugin-fate/index.js
@@ -6,32 +6,35 @@ module.exports = function configure(config, opts) {
   opts = opts || {};
 
   // Project's CSS. Run CSS in modules mode with postcss
-  config.loader('css', {
+  config.module.loaders.push({
     test: /\.css$/,
     exclude: /node_modules/,
     loader: ExtractTextPlugin.extract('style-loader', 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader')
   });
 
   // Project's global css. Run PostCSS but not modules mode.
-  config.loader('global-css', {
+  config.module.loaders.push({
     test: /\.global\.css$/,
     loader: ExtractTextPlugin.extract('style-loader', 'css-loader?importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader')
   });
 
   // Third Party CSS. From node_modules. Don't process, just load.
-  config.loader('third-party-css', {
+  config.module.loaders.push({
     test: /\.css$/,
     include: /node_modules/,
     loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
   });
 
-  config.plugin('extract-css',
-    ExtractTextPlugin, ['styles.[contenthash].css', {
-      allChunks: true
-    }]);
+  const extract = new ExtractTextPlugin('styles.[contenthash].css', {
+    allChunks: true
+  });
+  if(config.plugins) {
+    config.plugins.push(extract);
+  } else {
+    config.plugins = [extract];
+  }
 
-  config.merge({
-    postcss: opts.postcss || [
+  config.postcss = opts.postcss || [
       require('postcss-import'),
       require('postcss-brand-colors'),
       require('postcss-constants')({
@@ -57,7 +60,6 @@ module.exports = function configure(config, opts) {
 //      require('immutable-css'),
       require('postcss-browser-reporter')
     ]
-  });
 
   return config;
 }

--- a/packages/leo-plugin-fate/package.json
+++ b/packages/leo-plugin-fate/package.json
@@ -22,7 +22,7 @@
     "@sa-labs/fate-core": "^0.0.6",
     "colorguard": "^1.0.1",
     "css-loader": "^0.23.0",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.4",
     "immutable-css": "^1.0.1",
     "list-selectors": "^2.0.0",
     "lost": "^6.6.3",

--- a/packages/leo-plugin-fate/package.json
+++ b/packages/leo-plugin-fate/package.json
@@ -33,7 +33,7 @@
     "postcss-cssstats": "^1.0.0",
     "postcss-font-magician": "^1.4.0",
     "postcss-import": "^7.1.3",
-    "postcss-loader": "^0.8.0",
+    "postcss-loader": "^1.2.0",
     "postcss-modular-scale": "^2.5.1",
     "postcss-nested": "^1.0.0",
     "postcss-responsive-type": "^0.3.2",

--- a/packages/leo-plugin-images/index.js
+++ b/packages/leo-plugin-images/index.js
@@ -5,7 +5,7 @@ module.exports = function configure(config) {
    * be some of the heavier assets on a site. In the future, we should implement
    * a gradual loading mechanism that loads a low-res image, then the high-res.
    */
-  config.loader('images', {
+  config.module.loaders.push({
     test: /\.(jpe?g|png|gif|svg)$/i,
     loaders: [
       'url-loader?limit=10000',

--- a/packages/leo-plugin-images/index.js
+++ b/packages/leo-plugin-images/index.js
@@ -5,12 +5,13 @@ module.exports = function configure(config) {
    * be some of the heavier assets on a site. In the future, we should implement
    * a gradual loading mechanism that loads a low-res image, then the high-res.
    */
-  config.module.loaders.push({
+  config.module.rules.push({
     test: /\.(jpe?g|png|gif|svg)$/i,
-    loaders: [
-      'url-loader?limit=10000',
-      'img-loader?minimize&progressive=true'
-    ]
+    use: [{
+      loader: 'url-loader?limit=10000'
+    }, {
+      loader: 'img-loader?minimize&progressive=true'
+    }]
   });
 
   return config;

--- a/packages/leo-plugin-markdown/index.js
+++ b/packages/leo-plugin-markdown/index.js
@@ -1,3 +1,6 @@
+const debug = require('debug')('leo-plugin-makdown');
+const webpack = require('webpack');
+
 var hljs = require('hljs-modules');
 function getMDInstance() {
   const md = require('markdown-it')({
@@ -19,15 +22,33 @@ function getMDInstance() {
   return md;
 }
 module.exports = function configure(config, opts) {
-  config.module.loaders.push({
+
+  if(opts && opts.instance) {
+    debug('instance style: custom');
+  } else {
+    debug('instance style: default');
+  }
+  config.module.rules.push({
     test: /\.md$/,
     exclude: /node_modules/,
-    loaders: ['@sa-labs/leo-plugin-markdown/loader']
+    use: [{
+      loader: '@sa-labs/leo-plugin-markdown/loader'
+    }]
+  });
+  const optsPlugin = new webpack.LoaderOptionsPlugin({
+    options: {
+      // TODO: context here is a hack because we can't use multiple loaderOptionPlugins.
+      context: process.cwd(),
+      '@saLabs/leoPluginMarkdown/loader': {
+        instance: opts && opts.instance || getMDInstance()
+      },
+    },
   });
 
-  config.resolve.extensions.push('.md');
-  config['@saLabs/leoPluginMarkdown/loader'] = {
-    instance: opts && opts.instance || getMDInstance()
+  if(config.plugins) {
+    config.plugins.push(optsPlugin);
+  } else {
+    config.plugins = [optsPlugin];
   }
 
   return config;

--- a/packages/leo-plugin-markdown/index.js
+++ b/packages/leo-plugin-markdown/index.js
@@ -19,19 +19,16 @@ function getMDInstance() {
   return md;
 }
 module.exports = function configure(config, opts) {
-  config.loader('markdown', {
+  config.module.loaders.push({
     test: /\.md$/,
     exclude: /node_modules/,
     loaders: ['@sa-labs/leo-plugin-markdown/loader']
   });
 
-  config.merge(current => {
-    current.resolve.extensions.push('.md');
-    current['@saLabs/leoPluginMarkdown/loader'] = {
-      instance: opts && opts.instance || getMDInstance()
-    }
-    return current;
-  })
+  config.resolve.extensions.push('.md');
+  config['@saLabs/leoPluginMarkdown/loader'] = {
+    instance: opts && opts.instance || getMDInstance()
+  }
 
   return config;
 }

--- a/packages/leo-plugin-markdown/package.json
+++ b/packages/leo-plugin-markdown/package.json
@@ -20,5 +20,8 @@
     "lodash": "^4.0.0",
     "markdown-it": "^5.1.0",
     "slug": "^0.9.1"
+  },
+  "devDependencies": {
+    "jest": "^18.1.0"
   }
 }


### PR DESCRIPTION
Removes webpack configurator in favor of regular object access. I think configurator was nice in some respects but overall didn't add enough to be worth rewriting to ensure webpack 2.0 compat.

Shore up the graphql-directory-api tests

Add `leo build`, which is intended to be the "one-off for production" command. `leo develop` will turn into a webpack-dev-server style situation. Should think about whether `leo develop` or `leo build --develop` makes more sense.

TODO:

#### Docs
* Plugins
  - [ ] Pipeline/bundle plugin options
  - [ ] Scaffolding (client, static, html)
  - [ ] Adding Content Types to config (index, schema)
  - [ ] Post Processing (process.js)
* [ ] Commands (build, develop, update-schema, API)
* [ ] Creating Content Types from markdown files, Contentful, git repos, etc (How data is processed and the "API" is created)
* [ ] data as source of truth (urls, etc)
* [ ] leo.config.js

#### Other
- [ ] Update [blog starter](https://github.com/superawesomelabs/leo-blog-starter)
- [ ] Deal with iconv-loader warning in static bundle? It's annoying for regular usage to show this.